### PR TITLE
Support failure warnings in IWorkItemLinkMapper.Map()

### DIFF
--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -87,7 +87,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 }
             });
 
-            Assert.AreEqual(1, workItems.Length);
+            Assert.IsTrue(workItems.Succeeded);
+            Assert.AreEqual(1, workItems.Value.Length);
         }
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.3-enh-wit-errors0004" />
     <PackageReference Include="Octopus.Shared" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using Octokit;
+using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
@@ -29,7 +30,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
         public string CommentParser => GitHubConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public WorkItemLink[] Map(OctopusPackageMetadata packageMetadata)
+        public ExtResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
         {
             if (packageMetadata.CommentParser != CommentParser)
                 return null;

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -30,7 +30,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
         public string CommentParser => GitHubConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public ExtResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
+        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata)
         {
             if (packageMetadata.CommentParser != CommentParser)
                 return null;


### PR DESCRIPTION
Responds to an API change in OctopusDeploy/ServerExtensibility#20. No change to behaviour.