### PR TITLE
renaming PackageMetadata and changing the way the commentParser works

### DIFF
--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -14,6 +14,6 @@
     <PackageProjectUrl>https://github.com/OctopusDeploy/GitHubIssueTracker</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Client" Version="6.3.2" />
+    <PackageReference Include="Octopus.Client" Version="7.2.0" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/CommentParserScenarios.cs
+++ b/source/Server.Tests/CommentParserScenarios.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using NUnit.Framework;
 using Octopus.Server.Extensibility.HostServices.Model.IssueTrackers;
-using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
+using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
@@ -83,9 +83,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             Assert.AreEqual("#1234", reference.LinkData);
         }
 
-        private OctopusPackageMetadata Create(string comment)
+        private OctopusBuildInformation Create(string comment)
         {
-            return new OctopusPackageMetadata
+            return new OctopusBuildInformation
             {
                 Commits = new[] { new Commit{ Id = "a", Comment = comment }}
             };

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.0" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Octopus.Data" Version="4.2.0" />
+    <PackageReference Include="Octopus.Data" Version="4.2.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Data" Version="4.2.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.0.3-enh-buildinforen0004" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/WorkItems/CommentParser.cs
+++ b/source/Server/WorkItems/CommentParser.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
-using Octopus.Server.Extensibility.HostServices.Model.PackageMetadata;
+using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
 {
@@ -8,9 +8,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
     {
         private static readonly Regex Expression = new Regex("(?:close[d|s]*|fix[ed|es]*|resolve[d|s]*):?\\s((?:[A-Z0-9/_.-]*#|GH-|http[/A-Z:.]*/issues/)(\\d+))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         
-        public WorkItemReference[] ParseWorkItemReferences(OctopusPackageMetadata packageMetadata)
+        public WorkItemReference[] ParseWorkItemReferences(OctopusBuildInformation buildInformation)
         {
-            return packageMetadata.Commits.SelectMany(c => ParseReferences(c.Comment))
+            return buildInformation.Commits.SelectMany(c => ParseReferences(c.Comment))
                 .ToArray();
         }
 


### PR DESCRIPTION

Relates to OctopusDeploy/Issues#5885