### PR TITLE
Pass a logger and package identifiers to `IWorkItemLinkMapper`

### DIFF
--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0002" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -8,6 +8,7 @@ using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems;
+using Octopus.Versioning.Semver;
 using Commit = Octopus.Server.Extensibility.HostServices.Model.IssueTrackers.Commit;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
@@ -77,7 +78,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
 
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy);
 
-            var workItems = mapper.Map(new OctopusBuildInformation
+            var workItems = mapper.Map("P", new SemanticVersion("1"), new OctopusBuildInformation
             {
                 VcsRoot = "https://github.com/UserX/RepoY",
                 VcsType = "Git",
@@ -108,7 +109,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
 
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy);
 
-            var workItems = mapper.Map(new OctopusBuildInformation
+            var workItems = mapper.Map("P", new SemanticVersion("1"), new OctopusBuildInformation
             {
                 VcsRoot = "https://github.com/UserX/RepoY",
                 VcsType = "Git",

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NSubstitute;
 using NUnit.Framework;
 using Octokit;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems;
@@ -85,7 +86,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                     new Commit { Id = "abcd", Comment = "This is a test commit message. Fixes #1234"},
                     new Commit { Id = "defg", Comment = "This is a test commit message with duplicates. Fixes #1234"}
                 }
-            });
+            }, Substitute.For<ILogWithContext>());
 
             Assert.IsTrue(workItems.Succeeded);
             Assert.AreEqual(1, workItems.Value.Length);
@@ -115,7 +116,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 {
                     new Commit { Id = "abcd", Comment = "This is a test commit message. Fixes #1234"}
                 }
-            });
+            }, Substitute.For<ILogWithContext>());
 
             Assert.IsTrue(workItems.Succeeded);
             Assert.AreEqual("GitHub", workItems.Value.Single().Source);

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Data" Version="4.2.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0002" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Octopus.Data" Version="4.2.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -8,6 +8,7 @@ using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
 using Octopus.Server.Extensibility.Resources.IssueTrackers;
+using Octopus.Versioning;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
 {
@@ -31,7 +32,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
         public string CommentParser => GitHubConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation, ILogWithContext log)
+        public SuccessOrErrorResult<WorkItemLink[]> Map(string packageId, IVersion version, OctopusBuildInformation buildInformation, ILogWithContext log)
         {
             if (!IsEnabled)
                 return null;

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using Octokit;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
@@ -30,7 +31,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
         public string CommentParser => GitHubConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
+        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation, ILogWithContext log)
         {
             if (!IsEnabled)
                 return null;


### PR DESCRIPTION
To match OctopusDeploy/ServerExtensibility#25.

Part of a solution to OctopusDeploy/Issues#5869.