### PR TITLE
Return nothing if asked to parse Azure DevOps work items

### DIFF
--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -39,6 +39,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
             if (string.IsNullOrWhiteSpace(baseUrl))
                 return null;
 
+            if (buildInformation.VcsRoot.Contains(@"/_git/"))
+                return null;
+
             var releaseNotePrefix = store.GetReleaseNotePrefix();
             var workItemReferences = commentParser.ParseWorkItemReferences(buildInformation);
 

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -39,7 +39,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
             if (string.IsNullOrWhiteSpace(baseUrl))
                 return null;
 
-            if (buildInformation.VcsRoot.Contains(@"/_git/"))
+            const string pathComponentIndicatingAzureDevOpsVcs = @"/_git/";
+            if (buildInformation.VcsRoot.Contains(pathComponentIndicatingAzureDevOpsVcs))
                 return null;
 
             var releaseNotePrefix = store.GetReleaseNotePrefix();


### PR DESCRIPTION
# Background

The GitHub issue tracker recognizes GitHub Issue references in commit messages, for example `Fixes #1234.` Because Azure DevOps can use similar references to its Work Items, those can be mistaken for GitHub Issue references.

# Change

We don't want to assume work item location based on build environment, because somebody can keep source and Issues in GitHub and just use Azure DevOps for builds, the same way we use TeamCity.

We don't have a clear way to indicate the VCS URL *is* GitHub, because GitHub Enterprise can use a custom domain, and the URLs are quite minimal.

But we can at least avoid mistaking an Azure DevOps VCS URL, because it's easily recognizable by its `/_git/` substring.

This change prevents the behaviour where work item URLs could get assembled with a GitHub suffix on an Azure DevOps prefix: `https://octopussamples@dev.azure.com/octopussamples/OctoFX/_git/OctoFX/issues/8`

That example occurred in packages from the `octopussamples/OctoFX` Azure DevOps instance - https://samples.octopus.app/app#/Spaces-202/library/buildinformation/BuildInformation-1809