### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -110,8 +110,8 @@ Task("__Pack")
         CreateDirectory(extPublishDir);
         CopyFileToDirectory(Path.Combine("BuildAssets", "Server.nuspec"), extPublishDir);
 
-		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.0", $"*.{extensionName}.dll"), extPublishDir);
-		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.0", $"Octokit.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.1", $"*.{extensionName}.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.1", $"Octokit.dll"), extPublishDir);
 
         NuGetPack(Path.Combine(extPublishDir, "Server.nuspec"), new NuGetPackSettings {
             Version = nugetVersion,

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.IssueTracker.GitHub.Tests</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.IssueTracker.GitHub.Tests</AssemblyName>
+    <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Assent" Version="1.3.0" />
@@ -15,7 +17,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="8.1.1-enh-nevermore2-0010" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0002" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using NSubstitute;
 using NUnit.Framework;
 using Octokit;
+using Octopus.Data;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems;
+using Octopus.Server.Extensibility.Resources.IssueTrackers;
 using Commit = Octopus.Server.Extensibility.HostServices.Model.IssueTrackers.Commit;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
@@ -40,7 +42,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             var githubClient = Substitute.For<IGitHubClient>();
             var githubClientLazy = new Lazy<IGitHubClient>(() => githubClient);
             var workItemNumber = Convert.ToInt32(issueNumber);
-            
+
             githubClient.Issue.Get(Arg.Is(expectedOwner), Arg.Is(expectedRepo), Arg.Is(workItemNumber))
                 .Returns(new Issue("url", "htmlUrl", "commentUrl", "eventsUrl", workItemNumber, ItemState.Open, "Test title", "test body", null, null, new List<Octokit.Label>(), null, new List<Octokit.User>(), null, 1, null, null, DateTimeOffset.Now, null, workItemNumber, "node", false, null, null));
             githubClient.Issue.Comment.GetAllForIssue(Arg.Is(expectedOwner), Arg.Is(expectedRepo), Arg.Is(workItemNumber)).Returns(new []
@@ -70,7 +72,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             store.GetIsEnabled().Returns(true);
 
             var workItemNumber = 1234;
-            
+
             githubClient.Issue.Get(Arg.Is("UserX"), Arg.Is("RepoY"), Arg.Is(workItemNumber))
                 .Returns(new Issue("url", "htmlUrl", "commentUrl", "eventsUrl", workItemNumber, ItemState.Open, "Test title", "test body", null, null, new List<Octokit.Label>(), null, new List<Octokit.User>(), null, 0, null, null, DateTimeOffset.Now, null, workItemNumber, "node", false, null, null));
 
@@ -87,8 +89,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 }
             });
 
-            Assert.IsTrue(workItems.WasSuccessful);
-            Assert.AreEqual(1, workItems.Value.Length);
+            Assert.AreEqual(1, ((ISuccessResult<WorkItemLink[]>)workItems).Value.Length);
         }
 
         [Test]
@@ -101,7 +102,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             store.GetIsEnabled().Returns(true);
 
             var workItemNumber = 1234;
-            
+
             githubClient.Issue.Get(Arg.Is("UserX"), Arg.Is("RepoY"), Arg.Is(workItemNumber))
                 .Returns(new Issue("url", "htmlUrl", "commentUrl", "eventsUrl", workItemNumber, ItemState.Open, "Test title", "test body", null, null, new List<Octokit.Label>(), null, new List<Octokit.User>(), null, 0, null, null, DateTimeOffset.Now, null, workItemNumber, "node", false, null, null));
 
@@ -117,8 +118,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 }
             });
 
-            Assert.IsTrue(workItems.WasSuccessful);
-            Assert.AreEqual("GitHub", workItems.Value.Single().Source);
+            Assert.AreEqual("GitHub", ((ISuccessResult<WorkItemLink[]>)workItems).Value.Single().Source);
         }
     }
 }

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -87,7 +87,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 }
             });
 
-            Assert.IsTrue(workItems.Succeeded);
+            Assert.IsTrue(workItems.WasSuccessful);
             Assert.AreEqual(1, workItems.Value.Length);
         }
 
@@ -117,7 +117,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 }
             });
 
-            Assert.IsTrue(workItems.Succeeded);
+            Assert.IsTrue(workItems.WasSuccessful);
             Assert.AreEqual("GitHub", workItems.Value.Single().Source);
         }
     }

--- a/source/Server/Configuration/GitHubConfiguration.cs
+++ b/source/Server/Configuration/GitHubConfiguration.cs
@@ -12,14 +12,14 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
         }
 
         [Required]
-        public string BaseUrl { get; set; }
+        public string? BaseUrl { get; set; }
         public ReleaseNoteOptions ReleaseNoteOptions { get; set; } = new ReleaseNoteOptions();
     }
 
     class ReleaseNoteOptions
     {
-        public string Username { get; set; }
-        public SensitiveString Password { get; set; }
-        public string ReleaseNotePrefix { get; set; }
+        public string? Username { get; set; }
+        public SensitiveString? Password { get; set; }
+        public string? ReleaseNotePrefix { get; set; }
     }
 }

--- a/source/Server/Configuration/GitHubConfigurationResource.cs
+++ b/source/Server/Configuration/GitHubConfigurationResource.cs
@@ -18,7 +18,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
         [Description(GitHubBaseUrlDescription)]
         [Required]
         [Writeable]
-        public string BaseUrl { get; set; }
+        public string? BaseUrl { get; set; }
 
         [DisplayName("Release Note Options")]
         public ReleaseNoteOptionsResource ReleaseNoteOptions { get; set; } = new ReleaseNoteOptionsResource();
@@ -33,16 +33,16 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
         [DisplayName("Username")]
         [Description(UsernameDescription)]
         [Writeable]
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
         [DisplayName("Password")]
         [Description(PasswordDescription)]
         [Writeable]
-        public SensitiveValue Password { get; set; }
+        public SensitiveValue? Password { get; set; }
 
         [DisplayName("Release Note Prefix")]
         [Description(ReleaseNotePrefixDescription)]
         [Writeable]
-        public string ReleaseNotePrefix { get; set; }
+        public string? ReleaseNotePrefix { get; set; }
     }
 }

--- a/source/Server/Configuration/GitHubConfigurationSettings.cs
+++ b/source/Server/Configuration/GitHubConfigurationSettings.cs
@@ -1,18 +1,14 @@
 ﻿using System.Collections.Generic;
 using Octopus.Data.Model;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Server.Extensibility.HostServices.Licensing;
 using Octopus.Server.Extensibility.HostServices.Mapping;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
 {
     class GitHubConfigurationSettings : ExtensionConfigurationSettings<GitHubConfiguration, GitHubConfigurationResource, IGitHubConfigurationStore>, IGitHubConfigurationSettings
     {
-        private readonly IInstallationIdProvider installationIdProvider;
-
-        public GitHubConfigurationSettings(IGitHubConfigurationStore configurationDocumentStore, IInstallationIdProvider installationIdProvider) : base(configurationDocumentStore)
+        public GitHubConfigurationSettings(IGitHubConfigurationStore configurationDocumentStore) : base(configurationDocumentStore)
         {
-            this.installationIdProvider = installationIdProvider;
         }
 
         public override string Id => GitHubConfigurationStore.SingletonId;
@@ -26,10 +22,10 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
             var isEnabled = ConfigurationDocumentStore.GetIsEnabled();
 
             yield return new ConfigurationValue<bool>("Octopus.IssueTracker.GitHubIssueTracker", isEnabled, isEnabled, "Is Enabled");
-            yield return new ConfigurationValue<string>("Octopus.IssueTracker.GitHubBaseUrl", ConfigurationDocumentStore.GetBaseUrl(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetBaseUrl()), "GitHub Base Url");
-            yield return new ConfigurationValue<string>("Octopus.IssueTracker.GitHubUsername", ConfigurationDocumentStore.GetUsername(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetUsername()), "GitHub Username");
-            yield return new ConfigurationValue<SensitiveString>("Octopus.IssueTracker.GitHubPassword", ConfigurationDocumentStore.GetPassword(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetPassword()?.Value), "GitHub Password");
-            yield return new ConfigurationValue<string>("Octopus.IssueTracker.GitHubReleaseNotePrefix", ConfigurationDocumentStore.GetReleaseNotePrefix(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetReleaseNotePrefix()), "GitHub Release Note Prefix");
+            yield return new ConfigurationValue<string?>("Octopus.IssueTracker.GitHubBaseUrl", ConfigurationDocumentStore.GetBaseUrl(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetBaseUrl()), "GitHub Base Url");
+            yield return new ConfigurationValue<string?>("Octopus.IssueTracker.GitHubUsername", ConfigurationDocumentStore.GetUsername(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetUsername()), "GitHub Username");
+            yield return new ConfigurationValue<SensitiveString?>("Octopus.IssueTracker.GitHubPassword", ConfigurationDocumentStore.GetPassword(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetPassword()?.Value), "GitHub Password");
+            yield return new ConfigurationValue<string?>("Octopus.IssueTracker.GitHubReleaseNotePrefix", ConfigurationDocumentStore.GetReleaseNotePrefix(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetReleaseNotePrefix()), "GitHub Release Note Prefix");
         }
 
         public override void BuildMappings(IResourceMappingsBuilder builder)

--- a/source/Server/Configuration/GitHubConfigurationStore.cs
+++ b/source/Server/Configuration/GitHubConfigurationStore.cs
@@ -15,42 +15,42 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
 
         public override string Id => SingletonId;
 
-        public string GetBaseUrl()
+        public string? GetBaseUrl()
         {
             return GetProperty(doc => doc.BaseUrl?.Trim('/'));
         }
 
-        public void SetBaseUrl(string baseUrl)
+        public void SetBaseUrl(string? baseUrl)
         {
             SetProperty(doc => doc.BaseUrl = baseUrl?.Trim('/'));
         }
 
-        public string GetUsername()
+        public string? GetUsername()
         {
             return GetProperty(doc => doc.ReleaseNoteOptions.Username);
         }
 
-        public void SetUsername(string username)
+        public void SetUsername(string? username)
         {
             SetProperty(doc => doc.ReleaseNoteOptions.Username = username);
         }
 
-        public SensitiveString GetPassword()
+        public SensitiveString? GetPassword()
         {
             return GetProperty(doc => doc.ReleaseNoteOptions.Password);
         }
 
-        public void SetPassword(SensitiveString password)
+        public void SetPassword(SensitiveString? password)
         {
             SetProperty(doc => doc.ReleaseNoteOptions.Password = password);
         }
 
-        public string GetReleaseNotePrefix()
+        public string? GetReleaseNotePrefix()
         {
             return GetProperty(doc => doc.ReleaseNoteOptions.ReleaseNotePrefix);
         }
 
-        public void SetReleaseNotePrefix(string releaseNotePrefix)
+        public void SetReleaseNotePrefix(string? releaseNotePrefix)
         {
             SetProperty(doc => doc.ReleaseNoteOptions.ReleaseNotePrefix = releaseNotePrefix);
         }

--- a/source/Server/Configuration/IGitHubConfigurationStore.cs
+++ b/source/Server/Configuration/IGitHubConfigurationStore.cs
@@ -1,21 +1,20 @@
-﻿using System;
-using Octopus.Data.Model;
+﻿using Octopus.Data.Model;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration
 {
     interface IGitHubConfigurationStore : IExtensionConfigurationStore<GitHubConfiguration>
     {
-        string GetBaseUrl();
-        void SetBaseUrl(string baseUrl);
+        string? GetBaseUrl();
+        void SetBaseUrl(string? baseUrl);
 
-        string GetUsername();
-        void SetUsername(string username);
+        string? GetUsername();
+        void SetUsername(string? username);
 
-        SensitiveString GetPassword();
-        void SetPassword(SensitiveString password);
+        SensitiveString? GetPassword();
+        void SetPassword(SensitiveString? password);
 
-        string GetReleaseNotePrefix();
-        void SetReleaseNotePrefix(string releaseNotePrefix);
+        string? GetReleaseNotePrefix();
+        void SetReleaseNotePrefix(string? releaseNotePrefix);
     }
 }

--- a/source/Server/GitHubIssueTracker.cs
+++ b/source/Server/GitHubIssueTracker.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Octopus.Server.Extensibility.Extensions.WorkItems;
+﻿using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
 
 namespace Octopus.Server.Extensibility.IssueTracker.GitHub
@@ -20,6 +19,6 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub
 
         public bool IsEnabled => configurationStore.GetIsEnabled();
 
-        public string BaseUrl => configurationStore.GetIsEnabled() ? configurationStore.GetBaseUrl() : null;
+        public string? BaseUrl => configurationStore.GetIsEnabled() ? configurationStore.GetBaseUrl() : null;
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.IssueTracker.GitHub</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.IssueTracker.GitHub</AssemblyName>
     <Description>Implements the GitHub issue tracker.</Description>
@@ -8,13 +8,14 @@
     <Authors>Octopus Deploy</Authors>
     <PackageId>Octopus.Server.Extensibility.IssueTracker.GitHub</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/GitHubIssueTracker/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/GitHubIssueTracker</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Octopus.Data" Version="5.0.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="8.1.1-enh-nevermore2-0010" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Data" Version="5.1.2-ci0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0002" />
   </ItemGroup>
 </Project>

--- a/source/Server/WorkItems/CommentParser.cs
+++ b/source/Server/WorkItems/CommentParser.cs
@@ -17,7 +17,6 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
         internal static WorkItemReference[] ParseReferences(string comment)
         {
             return Expression.Matches(comment)
-                .Cast<Match>()
                 .Select(m => new WorkItemReference
                 {
                     IssueNumber = m.Groups[2].Value,
@@ -28,8 +27,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
 
         public class WorkItemReference
         {
-            public string IssueNumber { get; set; }
-            public string LinkData { get; set; }
+            public string IssueNumber { get; set; } = string.Empty;
+            public string LinkData { get; set; } = string.Empty;
         }
     }
 }


### PR DESCRIPTION
Changing the method return types to align with the new nullable patterns we've set up in ServerExtensibility.

Depends on:
OctopusDeploy/ServerExtensibility#66