### PR TITLE
Support SSH root URLs when generating work item links

### DIFF
--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -55,6 +55,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
         [TestCase("https://github.com", "https://github.com/UserX/RepoY", "UserX/RepoZ#1234", ExpectedResult = "https://github.com/UserX/RepoZ/issues/1234")]
         [TestCase("https://github.com", "https://github.com/UserX/RepoY", "https://github.com/UserX/RepoY/issues/1234", ExpectedResult = "https://github.com/UserX/RepoY/issues/1234")]
         [TestCase("https://github.com", "", "UserX/RepoZ#1234", ExpectedResult = "https://github.com/UserX/RepoZ/issues/1234")]
+        [TestCase("https://github.com", "git@github.com:UserX/RepoY", "#1234", ExpectedResult = "https://github.com/UserX/RepoY/issues/1234")]
         public string NormalizeLinkData(string baseUrl, string vcsRoot, string linkData)
         {
             return WorkItemLinkMapper.NormalizeLinkData(baseUrl, vcsRoot, linkData);

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -111,9 +111,21 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
                 linkDataComponents[0] = "issues";
             }
 
-            return baseToUse + "/" + string.Join("/", linkDataComponents);
+            return NormalizeBaseGitUrl(baseToUse) + "/" + string.Join("/", linkDataComponents);
         }
-        
+
+        static readonly Regex GitSshUrlRegex = new Regex("^git@(?<host>.*):", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        static string NormalizeBaseGitUrl(string vcsRoot)
+        {
+            var match = GitSshUrlRegex.Match(vcsRoot);
+            if (match.Success)
+            {
+                vcsRoot = GitSshUrlRegex.Replace(vcsRoot, $"https://{match.Groups["host"]}/");
+            }
+
+            return vcsRoot;
+        }
+
         (bool success, string owner, string repo) GetGitHubOwnerAndRepo(string gitHubUrl, string linkData)
         {
             (bool, string, string) GetOwnerRepoFromVcsRoot(string vcsRoot)


### PR DESCRIPTION
This PR will generate the correct http URL for work items when the VCS root is an SSH path.

There is test coverage for this case, and I have manually tested by integrating with Octopus.

Relates to OctopusDeploy/Issues#6467