### PR TITLE
Ignore comments when Build Information has been sourced from AzureDevOps

### DIFF
--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using NUnit.Framework;
 using Octokit;
 using Octopus.Data;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems;
@@ -50,7 +51,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
                 new IssueComment(0, null, null, null, releaseNoteComment, DateTimeOffset.Now, null, null, null)
             });
 
-            return new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy).GetReleaseNote(vcsRoot, issueNumber, linkData, releaseNotePrefix);
+            return new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy, Substitute.For<ILog>()).GetReleaseNote(vcsRoot, issueNumber, linkData, releaseNotePrefix);
         }
 
         [TestCase("https://github.com", "https://github.com/UserX/RepoY", "#1234", ExpectedResult = "https://github.com/UserX/RepoY/issues/1234")]
@@ -77,7 +78,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             githubClient.Issue.Get(Arg.Is("UserX"), Arg.Is("RepoY"), Arg.Is(workItemNumber))
                 .Returns(new Issue("url", "htmlUrl", "commentUrl", "eventsUrl", workItemNumber, ItemState.Open, "Test title", "test body", null, null, new List<Octokit.Label>(), null, new List<Octokit.User>(), null, 0, null, null, DateTimeOffset.Now, null, workItemNumber, "node", false, null, null));
 
-            var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy);
+            var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy, Substitute.For<ILog>());
 
             var workItems = mapper.Map(new OctopusBuildInformation
             {
@@ -107,7 +108,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             githubClient.Issue.Get(Arg.Is("UserX"), Arg.Is("RepoY"), Arg.Is(workItemNumber))
                 .Returns(new Issue("url", "htmlUrl", "commentUrl", "eventsUrl", workItemNumber, ItemState.Open, "Test title", "test body", null, null, new List<Octokit.Label>(), null, new List<Octokit.User>(), null, 0, null, null, DateTimeOffset.Now, null, workItemNumber, "node", false, null, null));
 
-            var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy);
+            var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy, Substitute.For<ILog>());
 
             var workItems = mapper.Map(new OctopusBuildInformation
             {

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -132,7 +132,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             store.GetBaseUrl().Returns("https://github.com");
             store.GetIsEnabled().Returns(true);
 
-            var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy, Substitute.For<ILog>());
+            var log = Substitute.For<ILog>();
+
+            var mapper = new WorkItemLinkMapper(store, new CommentParser(), githubClientLazy, log);
 
             var workItems = mapper.Map(new OctopusBuildInformation
             {
@@ -146,6 +148,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.Tests
             var success = workItems as ISuccessResult<WorkItemLink[]>;
             Assert.IsNotNull(success, "AzureDevOps VCS root should not be a failure");
             Assert.IsEmpty(success.Value, "AzureDevOps VCS root should return an empty list of links");
+            log.Received(1).WarnFormat("The VCS Root '{0}' indicates this build information is Azure DevOps related so GitHub comment references will be ignored", "https://something.com/_git/ProjectX");
         }
     }
 }

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -49,7 +49,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.GitHub.WorkItems
             const string pathComponentIndicatingAzureDevOpsVcs = @"/_git/";
             if (buildInformation.VcsRoot.Contains(pathComponentIndicatingAzureDevOpsVcs))
             {
-                log.WarnFormat("The VCS Root {0} indicates this build information is Azure DevOps related so GitHub comment references will be ignored");
+                log.WarnFormat("The VCS Root '{0}' indicates this build information is Azure DevOps related so GitHub comment references will be ignored", buildInformation.VcsRoot);
                 return ResultFromExtension<WorkItemLink[]>.Success(new WorkItemLink[0]);
             }
 


### PR DESCRIPTION
Finding an AzureDevOps VCS root means we should ignore GitHub style comment message references, the AzureDevOps issue tracker will handle this build information.

If we parse them here then they will get doubled up when the AzureDevOps issue tracker also adds them from the build links in ADO itself.

Relates to OctopusDeploy/Issues#6617